### PR TITLE
Update the nucular dependency to fix building on go-1.9 (#1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/vyskocilm/qrget
 
 require (
-	github.com/aarzilli/nucular v0.0.0-20181005081711-cc306f976081
+	github.com/aarzilli/nucular v0.0.0-20181005081711-9506b152e919
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/skip2/go-qrcode v0.0.0-20171229120447-cf5f9fa2f0d8
 )


### PR DESCRIPTION
Use the fix in https://github.com/aarzilli/nucular/issues/18